### PR TITLE
Switch to bitnami/nginx

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+/replace-markers.sh
+
+/opt/bitnami/scripts/nginx/entrypoint.sh "$@"
+
+echo ""
+exec "$@"

--- a/docker/replace-markers.sh
+++ b/docker/replace-markers.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
 
 # replace the markers in any javascript file.
-find /usr/share/nginx/html -type f -name '*.js' -exec \
+find /template_app -type f -name '*.js' -exec \
     sed -i \
         -e "s%@@KEYCLOAK_REALM@@%${KEYCLOAK_REALM}%" \
         -e "s%@@KEYCLOAK_URL@@%${KEYCLOAK_URL}%" \
         -e "s%@@KEYCLOAK_CLIENT_ID@@%${KEYCLOAK_CLIENT_ID}%" \
         -e "s%@@POC_MANAGER_API@@%${POC_MANAGER_API}%" \
         {} \;
+
+cp -a /template_app/* /www

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,9 +1,9 @@
 server {
   server_tokens off;
-  listen 80;
+  listen 8081;
   
   location / {
-    root   /usr/share/nginx/html;
+    root   /www;
     index  index.html index.htm;
     try_files $uri $uri/ /index.html;
     add_header Cache-Control 'no-store, no-cache, must-revalidate, proxy-revalidate';
@@ -12,6 +12,6 @@ server {
   }
   error_page   500 502 503 504  /50x.html;
   location = /50x.html {
-    root   /usr/share/nginx/html;
+    root   /app;
   }
 }


### PR DESCRIPTION
The reason for that is, that there is, that the bitnami nginx
is guaranteed to be functional when starting with a nonzero uid.
This comes with the side effect, that the container no longer
exposes port 80, but is now exposing port 8081

This fixes UD-66 and enables fixes for UD-61, UD-62 and UD-65.