### PR TITLE
UD-563: Enable Init container to run with ro fs

### DIFF
--- a/docker/replace-markers.sh
+++ b/docker/replace-markers.sh
@@ -1,12 +1,14 @@
 #!/bin/bash
 
+set -euo pipefail
+
+cp -a /template_app/* /www
+
 # replace the markers in any javascript file.
-find /template_app -type f -name '*.js' -exec \
+find /www -type f -name '*.js' -exec \
     sed -i \
         -e "s%@@KEYCLOAK_REALM@@%${KEYCLOAK_REALM}%" \
         -e "s%@@KEYCLOAK_URL@@%${KEYCLOAK_URL}%" \
         -e "s%@@KEYCLOAK_CLIENT_ID@@%${KEYCLOAK_CLIENT_ID}%" \
         -e "s%@@POC_MANAGER_API@@%${POC_MANAGER_API}%" \
         {} \;
-
-cp -a /template_app/* /www


### PR DESCRIPTION
This is necessary to comply with the newly introduced Gatekeeper PSP,
that requires all containers to have security contexts on QA. Also causes
the init script to fail if a command returns a non-zero exit code.