### PR TITLE
CPI-1125: no close button on notifications that disappear automatically

### DIFF
--- a/src/app/core/services/notification.service.ts
+++ b/src/app/core/services/notification.service.ts
@@ -27,8 +27,10 @@ export class NotificationService {
   }
 
   private openSnackBar(config: INotification) {
+      const calulatedDuration = config.duration ? config.duration > 0 ? config.duration : undefined : DEFAULT_NOTIFICATION_DURATION;
+      config.duration = calulatedDuration;
     this.notifications.openFromComponent(NotificationComponent, {
-      duration: config.duration ? config.duration > 0 ? config.duration : undefined : DEFAULT_NOTIFICATION_DURATION,
+      duration: calulatedDuration,
       data: config
     });
     return config;


### PR DESCRIPTION
notifications, that have a (default) duration and close automatically have no close button in the upper right corner